### PR TITLE
Using get on request META in case key isn't set

### DIFF
--- a/django_passbook/views.py
+++ b/django_passbook/views.py
@@ -3,7 +3,7 @@ from django.http import HttpResponse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import condition
 from django_passbook.models import Pass, Registration, Log
-from django.shortcuts import get_object_or_404, get_list_or_404
+from django.shortcuts import get_object_or_404
 from django.db.models import Max
 import django.dispatch
 from datetime import datetime
@@ -17,19 +17,30 @@ def registrations(request, device_library_id, pass_type_id):
     """
     Gets the Serial Numbers for Passes Associated with a Device
     """
-    passes = Pass.objects.filter(registration__device_library_identifier=device_library_id,
-                                 pass_type_identifier=pass_type_id)
+    passes = Pass.objects.filter(
+        registration__device_library_identifier=device_library_id,
+        pass_type_identifier=pass_type_id
+    )
     if passes.count() == 0:
         return HttpResponse(status=404)
 
     if 'passesUpdatedSince' in request.GET:
-        passes = passes.filter(updated_at__gt=datetime.strptime(request.GET['passesUpdatedSince'], FORMAT))
+        passes = passes.filter(updated_at__gt=datetime.strptime(
+            request.GET['passesUpdatedSince'], FORMAT))
 
     if passes:
         last_updated = passes.aggregate(Max('updated_at'))['updated_at__max']
-        serial_numbers = [p.serial_number for p in passes.filter(updated_at=last_updated).all()]
-        response_data = {'lastUpdated': last_updated.strftime(FORMAT), 'serialNumbers': serial_numbers}
-        return HttpResponse(json.dumps(response_data), mimetype="application/json")
+        serial_numbers = [
+            p.serial_number for p in passes.filter(
+                updated_at=last_updated
+            ).all()
+        ]
+        response_data = {'lastUpdated': last_updated.strftime(
+            FORMAT), 'serialNumbers': serial_numbers}
+        return HttpResponse(
+            json.dumps(response_data),
+            mimetype="application/json"
+        )
     else:
         return HttpResponse(status=204)
 
@@ -39,50 +50,56 @@ def register_pass(request, device_library_id, pass_type_id, serial_number):
     """
     Registers/Unregisters a Device to Receive Push Notifications for a Pass
     """
-    pazz = get_object_or_404(
-        Pass.objects.filter(pass_type_identifier=pass_type_id, serial_number=serial_number))
+    pass_ = get_pass(pass_type_id, serial_number)
 
-    if request.META['HTTP_AUTHORIZATION'] != 'ApplePass %s' % pazz.authentication_token:
+    if request.META.get(
+        'HTTP_AUTHORIZATION'
+    ) != 'ApplePass %s' % pass_.authentication_token:
         return HttpResponse(status=401)
 
-    registration = Registration.objects.filter(device_library_identifier=device_library_id,
-                                               pazz=pazz)
+    registration = Registration.objects.filter(
+        device_library_identifier=device_library_id,
+        pazz=pass_)
 
     if request.method == 'POST':
         if registration:
             return HttpResponse(status=200)
         body = json.loads(request.body)
-        new_registration = Registration(device_library_identifier=device_library_id,
-                                        push_token=body['pushToken'],
-                                        pazz=pazz)
+        new_registration = Registration(
+            device_library_identifier=device_library_id,
+            push_token=body['pushToken'],
+            pazz=pass_)
         new_registration.save()
-        pass_registered.send(sender=pazz)
+        pass_registered.send(sender=pass_)
         return HttpResponse(status=201)
 
     elif request.method == 'DELETE':
         registration.delete()
-        pass_unregistered.send(sender=pazz)
+        pass_unregistered.send(sender=pass_)
         return HttpResponse(status=200)
 
     else:
         return HttpResponse(status=400)
 
+
 def latest_pass(request, pass_type_id, serial_number):
-    return Pass.objects.get(pass_type_identifier=pass_type_id,
-                            serial_number=serial_number).updated_at
+    return get_pass(pass_type_id, serial_number).updated_at
+
 
 @condition(last_modified_func=latest_pass)
 def latest_version(request, pass_type_id, serial_number):
     """
     Gets the latest version of a Pass
     """
-    pass_ = get_object_or_404(
-        Pass.objects.filter(pass_type_identifier=pass_type_id, serial_number=serial_number))
+    pass_ = get_pass(pass_type_id, serial_number)
 
-    if request.META['HTTP_AUTHORIZATION'] != 'ApplePass %s' % pass_.authentication_token:
+    if request.META.get(
+        'HTTP_AUTHORIZATION'
+    ) != 'ApplePass %s' % pass_.authentication_token:
         return HttpResponse(status=401)
 
-    response = HttpResponse(pass_.data.read(), content_type='application/vnd.apple.pkpass')
+    response = HttpResponse(
+        pass_.data.read(), content_type='application/vnd.apple.pkpass')
     response['Content-Disposition'] = 'attachment; filename=pass.pkpass'
     return response
 
@@ -96,3 +113,11 @@ def log(request):
     for m in b['logs']:
         Log(message=m).save()
     return HttpResponse(status=200)
+
+
+def get_pass(pass_type_id, serial_number):
+    return get_object_or_404(
+        Pass,
+        pass_type_identifier=pass_type_id,
+        serial_number=serial_number
+    )


### PR DESCRIPTION
Hey Devartis,

Thanks for this most useful app. I have made a couple of small changes - mostly notably I have switch the authentication check to use request.META.get('HTTP_AUTHORIZATION'). This prevents a key error if the HTTP_AUTHORIZATION head is not sent.

Thanks again
